### PR TITLE
fix table loading icon for import-idc feature

### DIFF
--- a/platform/viewer/src/importIdc/ImportIdcModal.js
+++ b/platform/viewer/src/importIdc/ImportIdcModal.js
@@ -123,7 +123,7 @@ function ImportIdcModal({ isOpen = false, onClose, onSuccess, t }) {
     };
 
     UIModalService.show({
-      title: t('Tcia-Collections'),
+      title: t('Import-Idc'),
       content: ImportIdc,
       contentProps: {
         handleOnSuccess,

--- a/platform/viewer/src/importIdc/LoadingText.js
+++ b/platform/viewer/src/importIdc/LoadingText.js
@@ -4,8 +4,13 @@ import { Icon } from '../../../ui/src/elements/Icon';
 
 function LoadingText({ t: translate }) {
   return (
-    <div className="loading-text">
-      {translate('Loading')}... <Icon name="circle-notch" animation="pulse" />
+    <div className="loading-text ">
+      {translate('Loading')}...{' '}
+      <Icon
+        name="circle-notch"
+        className="loading-icon-spin"
+        animation="pulse"
+      />
     </div>
   );
 }

--- a/platform/viewer/src/studylist/StudyListRoute.js
+++ b/platform/viewer/src/studylist/StudyListRoute.js
@@ -207,7 +207,7 @@ function StudyListRoute(props) {
 
   const handleImportSuccessful = async UIModalService => {
     await fetchStudies();
-    UIModalService.hide();
+    if (UIModalService) UIModalService.hide();
     setShowImportIdcModal(false);
   };
 
@@ -256,7 +256,7 @@ function StudyListRoute(props) {
               className="btn btn-primary"
               onClick={() => setShowImportIdcModal(true)}
             >
-              {t(' Manage Collections')}
+              {t('Import IDC')}
             </button>
           </div>
 


### PR DESCRIPTION
### PR Checklist

- [ ] Brief description of changes
- [ ] Links to any relevant issues
- [ ] Required status checks are passing
- [ ] User cases if changes impact the user's experience
- [ ] `@mention` a maintainer to request a review

<!--
  Links
  -->

<!-- prettier-ignore-start -->
[blog]: https://circleci.com/blog/triggering-trusted-ci-jobs-on-untrusted-forks/
[script]: https://github.com/jklukas/git-push-fork-to-upstream-branch
<!-- prettier-ignore-end -->


fix import-idc table component loading icon not spinning 